### PR TITLE
Add encoding ultility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ More algorithm supports is one the way
 **Example**
 
 ```typescript
-import { AES } from "https://deno.land/x/god_crypto/mod.ts";
+import { AES } from "https://deno.land/x/god_crypto@v.1.1.0/mod.ts";
 
 const aes = new AES("Hello World AES!", {
   mode: "cbc",
   iv: "random 16byte iv",
 });
 
-const ciper = await aes.encrypt("This is AES-128-CBC. It works.");
-console.log(ciper.hex());
+const cipher = await aes.encrypt("This is AES-128-CBC. It works.");
+console.log(cipher.hex());
 // 41393374609eaee39fbe57c96b43a9da0d547c290501be50f983ecaac6c5fd1c
 
 const plain = await aes.decrypt(ciper);
@@ -54,18 +54,39 @@ new AES(key, {
 ## RSA
 
 ```typescript
-import { RSA } from "https://deno.land/x/god_crypto/mod.ts";
+import { RSA } from "https://deno.land/x/god_crypto@v.1.1.0/mod.ts";
 
 const publicKey = RSA.parseKey(Deno.readTextFileSync("./public.pem"));
-const ciper = await new RSA(publicKey).encrypt("Hello World");
+const cipher = await new RSA(publicKey).encrypt("Hello World");
 console.log(ciper.base64());
 
 const privateKey = RSA.parseKey(Deno.readTextFileSync("./private.pem"));
-const plain = await new RSA(privateKey).decrypt(ciper);
+const plain = await new RSA(privateKey).decrypt(cipher);
 console.log(plain.toString());
 
 // More examples:
 new RSA(publicKey);
 new RSA(publicKey, { padding: "oaep", hash: "sha256" });
 new RSA(publicKey, { padding: "pkcs1" });
+```
+
+## Other Ultility
+
+We also provide encoding ultility.
+
+```typescript
+import { encode } from "https://deno.land/x/god_crypto@v.1.1.0/mod.ts";
+
+// Converting hex to string
+encode.hex("676f645f63727970746f20726f636b7321").toString(); // "god_crypto rocks!"
+
+// Converting hex to base64
+encode.hex("676f645f63727970746f20726f636b7321").base64(); // Z29kX2NyeXB0byByb2NrcyE=
+
+// Converting base64 to hex
+encode.base64("Z29kX2NyeXB0byByb2NrcyE=").hex(); // 676f645f63727970746f20726f636b7321
+
+// Convert hex/base64 to Uint8Array
+encode.base64("Z29kX2NyeXB0byByb2NrcyE="); // Uint8Array object
+encode.hex("676f645f63727970746f20726f636b7321"); // Uint8Array object
 ```

--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,3 @@
 export * from "./src/rsa/mod.ts";
 export * from "./src/aes/mod.ts";
+export * from "./src/utility/encode.ts";

--- a/src/utility/encode.ts
+++ b/src/utility/encode.ts
@@ -1,0 +1,28 @@
+import { RawBinary } from "../binary.ts";
+
+export class encode {
+  static hex(data: string) {
+    if (data.length % 2 !== 0) throw "Invalid hex format";
+
+    const output = new RawBinary(data.length >> 1);
+    let ptr = 0;
+
+    for (let i = 0; i < data.length; i += 2) {
+      output[ptr++] = parseInt(data.substr(i, 2), 16);
+    }
+
+    return output;
+  }
+
+  static string(data: string) {
+    return new RawBinary(new TextEncoder().encode(data));
+  }
+
+  static base64(data: string) {
+    return new RawBinary(Uint8Array.from(atob(data), (c) => c.charCodeAt(0)));
+  }
+
+  static binary(data: Uint8Array | number[]) {
+    return new RawBinary(data);
+  }
+}

--- a/tests/aes/aes.openssl.test.ts
+++ b/tests/aes/aes.openssl.test.ts
@@ -2,7 +2,6 @@ import {
   assertEquals,
 } from "https://deno.land/std@0.63.0/testing/asserts.ts";
 import { AES } from "./../../mod.ts";
-import { RawBinary } from "../../src/binary.ts";
 
 Deno.test("AES - Decryption AES-128-CBC (OpenSSL)", async () => {
   // openssl enc -aes-128-cbc -in tests/aes/openssl_cleartext.txt -K 48656c6c6f20576f726c642041455321 -iv 72616e646f6d20313662797465206976 -out tests/aes/openssl_128_cbc.txt

--- a/tests/ultility/encode.test.ts
+++ b/tests/ultility/encode.test.ts
@@ -1,0 +1,26 @@
+import {
+  assertEquals,
+} from "https://deno.land/std@0.63.0/testing/asserts.ts";
+import { encode } from "./../../mod.ts";
+
+Deno.test("Encoding Utility", () => {
+  assertEquals(
+    encode.hex("676f645f63727970746f20726f636b7321").toString(),
+    "god_crypto rocks!",
+  );
+
+  assertEquals(
+    encode.string("god_crypto rocks!").hex(),
+    "676f645f63727970746f20726f636b7321",
+  );
+
+  assertEquals(
+    encode.base64("SGVsbG8gZ29kX2NyeXB0bw==").toString(),
+    "Hello god_crypto",
+  );
+
+  assertEquals(
+    encode.string("Hello god_crypto").base64(),
+    "SGVsbG8gZ29kX2NyeXB0bw==",
+  );
+});


### PR DESCRIPTION
Solving #5 request.

We can use `encode` to converting from different format to different format

```typescript
import { encode } from "https://deno.land/x/god_crypto@v.1.1.0/mod.ts";

// Converting hex to string
encode.hex("676f645f63727970746f20726f636b7321").toString(); // "god_crypto rocks!"

// Converting hex to base64
encode.hex("676f645f63727970746f20726f636b7321").base64(); // Z29kX2NyeXB0byByb2NrcyE=

// Converting base64 to hex
encode.base64("Z29kX2NyeXB0byByb2NrcyE=").hex(); // 676f645f63727970746f20726f636b7321

// Convert hex/base64 to Uint8Array
encode.base64("Z29kX2NyeXB0byByb2NrcyE="); // Uint8Array object
encode.hex("676f645f63727970746f20726f636b7321"); // Uint8Array object
```