### PR TITLE
(Fix) Deno 1.4.0 support added 

### DIFF
--- a/src/aes/aes_js.ts
+++ b/src/aes/aes_js.ts
@@ -7,8 +7,8 @@ import {
   BlockCiper,
   BlockCiperOperation,
 } from "./block_ciper_operator.ts";
-import { BlockCiperConfig } from "./common.ts";
-import { AESBase } from "./aes_base.ts";
+import type { BlockCiperConfig } from "./common.ts";
+import type { AESBase } from "./aes_base.ts";
 
 // deno-fmt-ignore
 const SBOX: number[] = [

--- a/src/aes/aes_wc.ts
+++ b/src/aes/aes_wc.ts
@@ -1,5 +1,5 @@
-import { AESBase } from "./aes_base.ts";
-import { BlockCiperConfig } from "./common.ts";
+import type { AESBase } from "./aes_base.ts";
+import type { BlockCiperConfig } from "./common.ts";
 
 function base64(m: Uint8Array) {
   return btoa(String.fromCharCode.apply(null, [...m])).replace(/=/g, "");

--- a/src/aes/block_ciper_operator.ts
+++ b/src/aes/block_ciper_operator.ts
@@ -1,5 +1,5 @@
 import { xor } from "./../helper.ts";
-import { BlockCiperConfig } from "./common.ts";
+import type { BlockCiperConfig } from "./common.ts";
 
 export abstract class BlockCiper {
   abstract encrypt(m: Uint8Array): Uint8Array;

--- a/src/aes/mod.ts
+++ b/src/aes/mod.ts
@@ -1,8 +1,8 @@
 import { RawBinary } from "../binary.ts";
-import { AESBase } from "./aes_base.ts";
+import type { AESBase } from "./aes_base.ts";
 import { WebCryptoAES } from "./aes_wc.ts";
 import { PureAES } from "./aes_js.ts";
-import { AESOption } from "./common.ts";
+import type { AESOption } from "./common.ts";
 
 function computeMessage(m: Uint8Array | string) {
   return typeof m === "string" ? new TextEncoder().encode(m) : m;

--- a/src/rsa/export_key.ts
+++ b/src/rsa/export_key.ts
@@ -1,4 +1,4 @@
-import { RSAKeyParams } from "./common.ts";
+import type { RSAKeyParams } from "./common.ts";
 import { bignum_to_byte } from "../helper.ts";
 import { encode } from "./../../src/utility/encode.ts";
 

--- a/src/rsa/import_key.ts
+++ b/src/rsa/import_key.ts
@@ -1,5 +1,5 @@
 import { encode } from "./../../src/utility/encode.ts";
-import { JSONWebKey, RSAKeyParams } from "./common.ts";
+import type { JSONWebKey, RSAKeyParams } from "./common.ts";
 import { get_key_size, base64_to_binary } from "../helper.ts";
 import { ber_decode, ber_simple } from "./basic_encoding_rule.ts";
 import { os2ip } from "./primitives.ts";

--- a/src/rsa/mod.ts
+++ b/src/rsa/mod.ts
@@ -1,4 +1,4 @@
-import { RSAOption, RSASignOption, JSONWebKey } from "./common.ts";
+import type { RSAOption, RSASignOption, JSONWebKey } from "./common.ts";
 import { WebCryptoRSA } from "./rsa_wc.ts";
 import { PureRSA } from "./rsa_js.ts";
 import { RawBinary } from "../binary.ts";

--- a/src/rsa/rsa_js.ts
+++ b/src/rsa/rsa_js.ts
@@ -7,9 +7,9 @@ import {
   rsa_pkcs1_sign,
 } from "./rsa_internal.ts";
 import { RawBinary } from "./../binary.ts";
-import { RSAOption, RSASignOption } from "./common.ts";
+import type { RSAOption, RSASignOption } from "./common.ts";
 import { createHash } from "../hash.ts";
-import { RSAKey } from "./rsa_key.ts";
+import type { RSAKey } from "./rsa_key.ts";
 
 export class PureRSA {
   static async encrypt(key: RSAKey, message: Uint8Array, options: RSAOption) {

--- a/src/rsa/rsa_key.ts
+++ b/src/rsa/rsa_key.ts
@@ -1,4 +1,4 @@
-import { RSAKeyParams, JSONWebKey } from "./common.ts";
+import type { RSAKeyParams, JSONWebKey } from "./common.ts";
 import { encode } from "./../../src/utility/encode.ts";
 import {
   rsa_export_pkcs8_private,

--- a/src/rsa/rsa_wc.ts
+++ b/src/rsa/rsa_wc.ts
@@ -1,5 +1,5 @@
-import { RSAOption } from "./common.ts";
-import { RSAKey } from "./rsa_key.ts";
+import type { RSAOption } from "./common.ts";
+import type { RSAKey } from "./rsa_key.ts";
 
 function big_base64(m?: bigint) {
   if (m === undefined) return undefined;


### PR DESCRIPTION
- Resolved warning : Import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'