### PR TITLE
Use /std/hash instead of denopkg.com/chiefbiiko

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,6 +1,6 @@
-import { sha1 } from "https://denopkg.com/chiefbiiko/sha1@v1.0.3/mod.ts";
-import { sha256 } from "https://denopkg.com/chiefbiiko/sha256@v1.0.2/mod.ts";
-import { sha512 } from "https://denopkg.com/chiefbiiko/sha512/mod.ts";
+import { Sha1 } from "https://deno.land/std@0.84.0/hash/sha1.ts";
+import { Sha256 } from "https://deno.land/std@0.84.0/hash/sha256.ts";
+import { Sha512 } from "https://deno.land/std@0.84.0/hash/sha512.ts";
 import { RSAHashAlgorithm } from "./rsa/common.ts";
 
 export function digest(
@@ -8,11 +8,11 @@ export function digest(
   m: Uint8Array,
 ): Uint8Array {
   if (algorithm === "sha1") {
-    return sha1(m) as Uint8Array;
+    return new Uint8Array(new Sha1().update(m).arrayBuffer());
   } else if (algorithm === "sha256") {
-    return sha256(m) as Uint8Array;
+    return new Uint8Array(new Sha256().update(m).arrayBuffer());
   } else if (algorithm === "sha512") {
-    return sha512(m) as Uint8Array;
+    return new Uint8Array(new Sha512().update(m).arrayBuffer());
   }
 
   throw "Unsupport hash algorithm";


### PR DESCRIPTION
Hello, I apologize for the unsolicited PR. It's come to my attention that denopkg.com imports break deno's compile caching since Deno 1.6.2. It seems related to the performed redirection. The result is that the Deno program is `Check`'d every run, even if nothing changed. Reported here: https://github.com/denoland/deno/issues/9129

I've felt unsure already about the chiefbiiko packages in use here, due to a couple instances of unversioned imports and also including unused base64 code via further imports. So I took this opportunity to plug in the `deno.land/std/hash` modules instead and it seems to be passing the test suite, working for my RSA JWT usecase, and not re-checking the types every time I use `deno run`.

I wasn't sure if there was any reason that this library uses the chiefbiiko sha modules, as opposed to the Deno stdlib hash module. If you have some attachment to the current configuration then of course feel free to close this unsolicited PR. Otherwise it seems like a net benefit to be using the "standard" implementation. For what it's worth I have not compared performance.

BTW: The djwt library that I'm using is already importing the /std/hash modules for its own HMAC hashing (as well as god_crypto for RSA), so this change would remove a duplicate sha implementation from the dependency tree of any djwt user.