### PR TITLE
fix `README.md` typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const publicKey = RSA.parseKey(Deno.readTextFileSync("./public.pem"));
 const privateKey = RSA.parseKey(Deno.readTextFileSync("./private.pem"));
 
 const cipher = await new RSA(publicKey).encrypt("Hello World");
-console.log(ciper.base64());
+console.log(cipher.base64());
 
 const plain = await new RSA(privateKey).decrypt(cipher);
 console.log(plain.toString());


### PR DESCRIPTION
I tripped over this myself for a hot second lol