### PR TITLE
DENO 2 related issue.  Update helper.ts

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,3 +1,5 @@
+import { decode as base64Decode } from "https://deno.land/std/encoding/base64.ts"; // Not sure where we should place imports ;)
+
 export function str2bytes(str: string): Uint8Array {
   const encoder = new TextEncoder();
   return encoder.encode(str);
@@ -57,13 +59,5 @@ export function get_key_size(n: bigint): number {
 }
 
 export function base64_to_binary(b: string): Uint8Array {
-  const binaryString = atob(b);
-  const len = binaryString.length;
-  const bytes = new Uint8Array(len);
-
-  for (let i = 0; i < len; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-
-  return bytes;
+  return base64Decode(b);
 }


### PR DESCRIPTION
update base64_to_binary function .

In browser JavaScript, atob() is used to decode a base64-encoded string. It's part of the Web APIs, which aren't natively available in Deno's runtime environment.

After enabling DENO_FUTURE=1 we now get thsi error :

error: Uncaught (in promise) ReferenceError: window is not defined
  let binaryString = window.atob(b);
                     ^
    at base64_to_binary (https://deno.land/x/god_crypto@v1.4.11/src/helper.ts:60:22)
    at rsa_import_pem_public (https://deno.land/x/god_crypto@v1.4.11/src/rsa/import_key.ts:132:16)
    at rsa_import_pem (https://deno.land/x/god_crypto@v1.4.11/src/rsa/import_key.ts:160:50)
    at rsa_import_key (https://deno.land/x/god_crypto@v1.4.11/src/rsa/import_key.ts:179:37)
    at Function.importKey (https://deno.land/x/god_crypto@v1.4.11/src/rsa/mod.ts:102:23)
    at Function.parseKey (https://deno.land/x/god_crypto@v1.4.11/src/rsa/mod.ts:89:17)

atob() is a global function in browser environments, typically accessed via window.atob(). In Deno, especially with DENO_FUTURE=1, this global function isn't available by default.